### PR TITLE
Add physics-based shot leading, hood sim, and SysId gains

### DIFF
--- a/commands/auto_align/align_with_controller.py
+++ b/commands/auto_align/align_with_controller.py
@@ -1,3 +1,5 @@
+from typing import Callable
+
 from wpilib import SmartDashboard
 from wpimath.geometry import Pose2d
 
@@ -27,7 +29,8 @@ class TurretToPose(alignio.TurretTargetWithVelocity):
         target: Pose2d,
         shooter: DualMotorShooter,
     ):
-        super().__init__(drivetrain, shooter, target)
+        super().__init__(drivetrain, target)
+        self._shooter = shooter
 
     def execute(self):
         rotation_rate = self.calculate_rotation()
@@ -57,6 +60,8 @@ class HubAlign(alignio.TurretTargetWithVelocity):
         self._hood.set_state(HoodStates.AUTO)
 
     def execute(self):
+        self._hood_angle_deg = self._hood.auto_hood_angle
+        self._velocity_efficiency = self._hood.nt.get("Velocity Efficiency")
         rotation_rate = self.calculate_rotation()
         self._drivetrain.set_target_align_rotation_rate(
             rotation_rate * kAutoAlign.AUTO_ALIGN_MAX_ANGULAR_RATE
@@ -78,9 +83,11 @@ class ConditionalAlignAndShoot(HubAlign):
         transfer_subsystem: TransferSubsystem,
         hood: ShooterHood,
         LED_controller: CANdleLEDController | None = None,
+        force_physics: Callable[[], bool] | None = None,
     ):
         super().__init__(drivetrain, shooter, hood, LED_controller)
         self.transfer_subsystem = transfer_subsystem
+        self._force_physics_supplier = force_physics or (lambda: False)
 
     def initialize(self):
         super().initialize()
@@ -88,6 +95,9 @@ class ConditionalAlignAndShoot(HubAlign):
 
     def execute(self):
         self.periodic()
+        # R Bumper + R Trigger overrides dashboard toggles to use physics calc
+        self._force_physics = self._force_physics_supplier()
+        self._hood.force_physics_aiming = self._force_physics
         super().execute()
         robot_pose = self._drivetrain.get_state().pose
 
@@ -122,6 +132,6 @@ class ConditionalAlignAndShoot(HubAlign):
 
     def end(self, interrupted):
         super().end(interrupted)
-
+        self._hood.force_physics_aiming = False
         self.transfer_subsystem.stop()
         self._shooter.disable()

--- a/commands/auto_align/alignio.py
+++ b/commands/auto_align/alignio.py
@@ -11,7 +11,7 @@ from wpimath.units import degrees, meters
 from wpilib import SmartDashboard
 
 from constants.drive import kAutoAlign
-from constants.shooter import kShooterConfig, kShooterData
+from constants.shooter import kShooterConfig, kShooterData, kShooterMotor, kHoodMotor
 
 from util.flip_util import FlipUtil
 from util import math_helpers
@@ -71,10 +71,18 @@ class TurretTargetWithVelocity(TurretTargetBase):
         self, drivetrain: SwerveDriveTrain, target: Pose2d
     ):
         super().__init__(drivetrain, target)
-        # self._shooter = shooter
         self.flight_time_scalar = kAutoAlign.FLIGHT_TIME_SCALAR
-        
+
         self._estimated_target_pose = Pose2d()
+        self._hood_angle_deg = 0.0  # overridden by HubAlign when hood is available
+        self._velocity_efficiency = kHoodMotor.VELOCITY_EFFICIENCY  # overridden by HubAlign with dashboard value
+        self._force_physics = False  # when True, bypass NTTable toggles
+
+        self.flight_nt = NTTable("Auto Align").get_subtable("Flight Time")
+        self.flight_nt.bool("Use Physics Flight Time", False)
+        self.flight_nt.float("Estimated Flight Time (s)", 0.0)
+        self.flight_nt.float("Lead Offset X (m)", 0.0)
+        self.flight_nt.float("Lead Offset Y (m)", 0.0)
 
     def calculate_rotation(self) -> float:
         drive_state = self._drivetrain.get_state()
@@ -101,17 +109,27 @@ class TurretTargetWithVelocity(TurretTargetBase):
 
         target_yaw = self.get_target_yaw(drive_state.pose, target_pose) + kAutoAlign.ALIGN_TUNER_OFFSET
         rotation_rate = self.rotation_PID.calculate(drive_state.heading, target_yaw)
-        
+
         error = drive_state.heading - target_yaw
         self.current_accuracy = abs((error + 180) % 360 - 180)
-        # if self.current_accuracy < kAutoAlign.REQUIRED_SHOOT_ACCURACY_DEGREES:
-        #     return 0
-        
+
+        # Telemetry
+        self.flight_nt.set("Estimated Flight Time (s)", round(ball_flight_time, 3))
+        self.flight_nt.set("Lead Offset X (m)", round(vel_offset.x, 3))
+        self.flight_nt.set("Lead Offset Y (m)", round(vel_offset.y, 3))
+
         return math_helpers.clamp(rotation_rate, -1.0, 1.0)
 
-    @staticmethod
-    def estimate_flight_time(distance: meters) -> float:
-        return 0
+    def estimate_flight_time(self, distance: float) -> float:
+        """Estimate ball flight time (seconds) to target.
+
+        Toggled via dashboard 'Use Physics Flight Time':
+          True  -> projectile kinematics (v * cos(theta))
+          False -> SHOT_TIME interpolation table
+        """
+        if self._force_physics or self.flight_nt.get("Use Physics Flight Time"):
+            return self._physics_flight_time(distance)
+
         interpolation_distance_data, interpolation_time_data = zip(
             *kShooterData.SHOT_TIME
         )
@@ -119,4 +137,18 @@ class TurretTargetWithVelocity(TurretTargetBase):
             np.interp(distance, interpolation_distance_data, interpolation_time_data)
         )
         return math_helpers.clamp(time, 0, 5)
+
+    def _physics_flight_time(self, distance: float) -> float:
+        """Flat-trajectory approximation: t = d / (v * cos(theta))."""
+        rpm = abs(kShooterMotor.CURRENT_TARGET_RPM)
+        v = rpm * kShooterConfig.EXIT_VELOCITY_FACTOR * self._velocity_efficiency
+        if v < 0.1:
+            return 0  # motor not spinning
+
+        theta_rad = math.radians(self._hood_angle_deg)
+        cos_theta = math.cos(theta_rad)
+        if cos_theta < 0.1:
+            return 0
+        t = distance / (v * cos_theta)
+        return math_helpers.clamp(t, 0, 5)
 

--- a/constants/shooter.py
+++ b/constants/shooter.py
@@ -35,7 +35,19 @@ class kHoodMotor:
     OVERRIDE_ANGLE_DEG = 25.0
     
     OPPOSING_ANGLE_DEG = 35.0
-    
+
+    # Physics-based aiming
+    MIN_ANGLE_DEG = 5.0              # explicit alias for HOME_ANGLE_DEG
+    HUB_HEIGHT_M = 1.8288            # target center height above ground (meters)
+    SHOOTER_HEIGHT_M = 0.3048        # hood pivot height above ground (meters)
+    VELOCITY_EFFICIENCY = 0.9        # fraction of theoretical exit velocity realized (tune down if overshooting)
+    EXIT_ANGLE_OFFSET_DEG = 0.0      # additive correction after physics calc (tune on robot)
+
+    # Simulation (SingleJointedArmSim — models the hood flap pivot)
+    ARM_LENGTH_M = 0.10              # hood flap length pivot-to-tip
+    ARM_MASS_KG = 0.15               # hood flap mass
+    SIM_GEARING = 15.1               # motor revolutions per output revolution
+
     @staticmethod
     def to_revs(degrees: float) -> float:
         return degrees * kHoodMotor.GEAR_RATIO
@@ -90,3 +102,4 @@ class kShooterConfig:
     SHOOTER_OFFSET = Translation2d(-10.432 * kMath.MetersPerInch, 0)  # Meters
     SHOOTER_DIRECTION = -90  # 180 for Reverse
     WHEEL_RADIUS = 4 * kMath.MetersPerInch
+    EXIT_VELOCITY_FACTOR = WHEEL_RADIUS * 2 * math.pi / 60  # RPM -> m/s at wheel surface

--- a/robotcontainer.py
+++ b/robotcontainer.py
@@ -134,12 +134,14 @@ class RobotContainer:
                 self.shooter_subsystem,
                 self.transfer_subsystem,
                 self.hood_subsystem,
+                force_physics=lambda: self._controller_1.rightBumper().getAsBoolean(),
             )
         )
 
         # self._controller_1.leftBumper().whileTrue(go_back_with_path.GoBackWithPath(self._drivetrain))
         
         self._controller_1.leftBumper().whileTrue(
+            
             ParallelCommandGroup(
                 go_to_shooting_spot.GoToShootingSpot(self._drivetrain),
                 shooter_commands.EnableShooter(self.shooter_subsystem)

--- a/subsystems/drivetrain/swerve_tuner.py
+++ b/subsystems/drivetrain/swerve_tuner.py
@@ -18,12 +18,20 @@ class TunerConstants:
     # output type specified by SwerveModuleConstants.SteerMotorClosedLoopOutput
     _steer_gains = (
         configs.Slot0Configs()
-        .with_k_p(40)
+        # .with_k_p(sum([0.010095, 0.13685, 0.02603, 0.15159])/4) # velocity loop
+        .with_k_p(sum([ 10.739, 13.242, 12.16, 7.1703])/4) # position loop
         .with_k_i(0)
-        .with_k_d(0.5)
-        .with_k_s(0.1)
-        .with_k_v(1.59)
-        .with_k_a(0)
+        .with_k_d(sum([ 0.11989, 0.26857, 0.37575,0.27463])/4)
+        .with_k_s(sum([0.35797,0.3839 , 0.45442,0.30588 ])/4)
+        .with_k_v(sum([1.3281, 1.3062, 1.0138, 1.1043 ])/4)
+        .with_k_a(sum([0.026809, 0.032434, 0.032061,  0.042059])/4)
+        #used at magnolia:
+        # .with_k_p(40)
+        # .with_k_i(0)
+        # .with_k_d(0.5)
+        # .with_k_s(0.1)
+        # .with_k_v(1.59)
+        # .with_k_a(0)
         .with_static_feedforward_sign(
             signals.StaticFeedforwardSignValue.USE_CLOSED_LOOP_SIGN
         )
@@ -32,11 +40,18 @@ class TunerConstants:
     # output type specified by SwerveModuleConstants.DriveMotorClosedLoopOutput
     _drive_gains = (
         configs.Slot0Configs()
-        .with_k_p(0.00442645)
+        .with_k_p(sum([ 0.092102 , 0.15798, 0.13838, 0.18059 ])/4)
         .with_k_i(0)
         .with_k_d(0)
-        .with_k_s(0.07664325)
-        .with_k_v(0.11412)
+        .with_k_s(sum([ 0.1569 , 0.072046, 0.066353 ,  0.078697 ])/4)
+        .with_k_v(sum([0.11654 , 0.11804, 0.11832, 0.11765 ])/4)
+        .with_k_a(sum([ 0.0043711 , 0.012229,  0.016051, 0.012999 ])/4)
+        #Used at Magnolia:
+        # .with_k_p(0.00442645)
+        # .with_k_i(0)
+        # .with_k_d(0)
+        # .with_k_s(0.07664325)
+        # .with_k_v(0.11412)
     )
 
     # The closed-loop output type to use for the steer motors;
@@ -56,7 +71,7 @@ class TunerConstants:
 
     # The stator current at which the wheels start to slip;
     # This needs to be tuned to your individual robot
-    _slip_current: units.ampere = 54.0 #originally 120.0
+    _slip_current: units.ampere = 80.0 #originally 120.0
 
     # Initial configs for the drive and steer motors and the azimuth encoder; these cannot be null.
     # Some configs will be overwritten; check the `with_*_initial_configs()` API documentation.

--- a/subsystems/drivetrain/swerve_tuner.py
+++ b/subsystems/drivetrain/swerve_tuner.py
@@ -19,12 +19,12 @@ class TunerConstants:
     _steer_gains = (
         configs.Slot0Configs()
         # .with_k_p(sum([0.010095, 0.13685, 0.02603, 0.15159])/4) # velocity loop
-        .with_k_p(sum([ 10.739, 13.242, 12.16, 7.1703])/4) # position loop
+        .with_k_p(10.82)#sum([ 10.739, 13.242, 12.16, 7.1703])/4) # position loop
         .with_k_i(0)
-        .with_k_d(sum([ 0.11989, 0.26857, 0.37575,0.27463])/4)
-        .with_k_s(sum([0.35797,0.3839 , 0.45442,0.30588 ])/4)
-        .with_k_v(sum([1.3281, 1.3062, 1.0138, 1.1043 ])/4)
-        .with_k_a(sum([0.026809, 0.032434, 0.032061,  0.042059])/4)
+        .with_k_d(0.25971)#sum([ 0.11989, 0.26857, 0.37575,0.27463])/4)
+        .with_k_s(0.1)#sum([0.35797,0.3839 , 0.45442,0.30588 ])/4)
+        .with_k_v(1.1881)#sum([1.3281, 1.3062, 1.0138, 1.1043 ])/4)
+        .with_k_a(0.03334075)#sum([0.026809, 0.032434, 0.032061,  0.042059])/4)
         #used at magnolia:
         # .with_k_p(40)
         # .with_k_i(0)
@@ -57,6 +57,7 @@ class TunerConstants:
     # The closed-loop output type to use for the steer motors;
     # This affects the PID/FF gains for the steer motors
     _steer_closed_loop_output = swerve.ClosedLoopOutputType.VOLTAGE
+    # _steer_closed_loop_output = swerve.ClosedLoopOutputType.VOLTAGE
     # The closed-loop output type to use for the drive motors;
     # This affects the PID/FF gains for the drive motors
     _drive_closed_loop_output = swerve.ClosedLoopOutputType.VOLTAGE
@@ -80,8 +81,8 @@ class TunerConstants:
         configs.CurrentLimitsConfigs()
         # Swerve azimuth does not require much torque output, so we can set a relatively low
         # stator current limit to help avoid brownouts without impacting performance.
-        # .with_stator_current_limit(60.0)
-        .with_stator_current_limit(35.0)
+        .with_stator_current_limit(60.0)
+        # used at magnolia:  .with_stator_current_limit(35.0)
         .with_stator_current_limit_enable(True)
     )
     _encoder_initial_configs = configs.CANcoderConfiguration()

--- a/subsystems/shooter/shooter_hood.py
+++ b/subsystems/shooter/shooter_hood.py
@@ -1,8 +1,14 @@
+import math
+
 import numpy as np
 
 from enum import Enum
 
 import wpilib
+from wpilib import RobotController
+from wpilib.simulation import SingleJointedArmSim
+from wpimath.system.plant import DCMotor
+from wpimath.units import degreesToRadians, radiansToDegrees
 
 from commands2 import Subsystem
 
@@ -18,7 +24,7 @@ from util.math_helpers import distanceFromPose2dtoPose2d, clamp
 
 from subsystems.drivetrain.driveio import CustomSwerve
 
-from constants.shooter import kHoodMotor, kShooterData
+from constants.shooter import kHoodMotor, kShooterData, kShooterMotor, kShooterConfig
 from constants.canbus import kCANId
 
 
@@ -34,6 +40,8 @@ class HoodStates(Enum):
 
 class ShooterHood(Subsystem):
     def __init__(self):
+        super().__init__()
+
         self._state: HoodStates = HoodStates.HIDE
         self._motor = TalonFXS(kCANId.shooter.HOOD_CONTROL, "rio")
 
@@ -46,6 +54,7 @@ class ShooterHood(Subsystem):
 
         self.hard_stopped = False
         self.auto_hood_angle = 5.0
+        self.force_physics_aiming = False  # set by align command when R Bumper held
 
         self.editable_pid = EditablePID("Shooter/Hood", self._motor, kHoodMotor._CONFIG)
 
@@ -54,7 +63,32 @@ class ShooterHood(Subsystem):
         self.nt.float("Target Angle (deg)", 0.0)
         self.nt.string("State", "HIDE")
 
+        # Physics-based aiming tuning (dashboard-editable)
+        self.nt.float("Velocity Efficiency", kHoodMotor.VELOCITY_EFFICIENCY)
+        self.nt.float("Exit Angle Offset (deg)", kHoodMotor.EXIT_ANGLE_OFFSET_DEG)
+        self.nt.bool("Use Physics Aiming", False)
+
         self._target_position_revs = 0
+
+        # Simulation
+        if wpilib.RobotBase.isSimulation():
+            _model = DCMotor.krakenX60(1)  # closest proxy for Minion motor
+            self._arm_sim = SingleJointedArmSim(
+                gearbox=_model,
+                gearing=kHoodMotor.SIM_GEARING,
+                moi=SingleJointedArmSim.estimateMOI(
+                    kHoodMotor.ARM_LENGTH_M, kHoodMotor.ARM_MASS_KG
+                ),
+                armLength=kHoodMotor.ARM_LENGTH_M,
+                minAngle=degreesToRadians(kHoodMotor.MIN_ANGLE_DEG),
+                maxAngle=degreesToRadians(kHoodMotor.MAX_ANGLE_DEG),
+                simulateGravity=True,
+                startingAngle=degreesToRadians(kHoodMotor.MIN_ANGLE_DEG),
+            )
+
+    # ------------------------------------------------------------------
+    # State & control
+    # ------------------------------------------------------------------
 
     def set_state(self, state: HoodStates) -> None:
         self._state = state
@@ -82,6 +116,10 @@ class ShooterHood(Subsystem):
             self._motor.get_reverse_limit().value is ReverseLimitValue.CLOSED_TO_GROUND
         )
 
+    # ------------------------------------------------------------------
+    # Aiming
+    # ------------------------------------------------------------------
+
     def add_auto_hood_measurement(
         self, drivestate: CustomSwerve.DriveState, target_pose: Pose2d
     ) -> None:
@@ -92,6 +130,54 @@ class ShooterHood(Subsystem):
         self.auto_hood_angle = clamp(
             interpolated_angle, kHoodMotor.HOME_ANGLE_DEG, kHoodMotor.MAX_ANGLE_DEG
         )
+
+    def get_angle_by_distance(self, distance: float) -> float:
+        """Return the target hood angle (degrees) for the given distance.
+
+        Uses physics-based projectile kinematics when 'Use Physics Aiming' is
+        enabled on the dashboard, otherwise falls back to the interpolation table.
+        """
+        if self.force_physics_aiming or self.nt.get("Use Physics Aiming"):
+            return self.calculate_hood_angle(distance)
+
+        interpolation_distance_data, interpolation_angle_data = zip(
+            *kShooterData.SHOT_ANGLES_MAGNOLIA
+        )
+        return float(
+            np.interp(distance, interpolation_distance_data, interpolation_angle_data)
+        )
+
+    def calculate_hood_angle(self, distance: float) -> float:
+        """Projectile kinematics: optimal low-trajectory launch angle (degrees).
+
+        Uses actual shooter RPM and wheel radius for exit velocity.
+        Tunable via dashboard:
+          - Velocity Efficiency: fraction of theoretical exit velocity realized
+          - Exit Angle Offset (deg): additive correction after physics calc
+        """
+        efficiency = self.nt.get("Velocity Efficiency")
+        offset_deg = self.nt.get("Exit Angle Offset (deg)")
+
+        rpm = abs(kShooterMotor.CURRENT_TARGET_RPM)
+        v = rpm * kShooterConfig.EXIT_VELOCITY_FACTOR * efficiency
+        if v < 0.1:
+            return kHoodMotor.MIN_ANGLE_DEG
+
+        delta_h = kHoodMotor.HUB_HEIGHT_M - kHoodMotor.SHOOTER_HEIGHT_M
+        g = 9.81
+
+        discriminant = v**4 - g * (g * distance**2 + 2 * delta_h * v**2)
+        if discriminant < 0:
+            return kHoodMotor.MAX_ANGLE_DEG  # can't reach — max loft
+
+        theta_rad = math.atan((v**2 - math.sqrt(discriminant)) / (g * distance))
+        theta_deg = math.degrees(theta_rad) + offset_deg
+
+        return max(kHoodMotor.MIN_ANGLE_DEG, min(kHoodMotor.MAX_ANGLE_DEG, theta_deg))
+
+    # ------------------------------------------------------------------
+    # State machine
+    # ------------------------------------------------------------------
 
     def _apply_angle(self) -> None:
         target_angle = kHoodMotor.HOME_ANGLE_DEG
@@ -111,6 +197,10 @@ class ShooterHood(Subsystem):
         target_revs = kHoodMotor.to_revs(target_angle)
         self.set_position(target_revs)
 
+    # ------------------------------------------------------------------
+    # Periodic
+    # ------------------------------------------------------------------
+
     def periodic(self) -> None:
         if self.is_hard_stopped() and not self.hard_stopped:
             self._motor.set_position(kHoodMotor.to_revs(kHoodMotor.HOME_ANGLE_DEG))
@@ -128,11 +218,28 @@ class ShooterHood(Subsystem):
 
         self.editable_pid.periodic()
 
-    @staticmethod
-    def get_angle_by_distance(distance: float) -> float:
-        interpolation_distance_data, interpolation_angle_data = zip(
-            *kShooterData.SHOT_ANGLES_MAGNOLIA
+    # ------------------------------------------------------------------
+    # Simulation
+    # ------------------------------------------------------------------
+
+    def simulationPeriodic(self):
+        self._motor.sim_state.set_supply_voltage(RobotController.getBatteryVoltage())
+        self._arm_sim.setInputVoltage(self._motor.sim_state.motor_voltage)
+        self._arm_sim.update(0.02)
+
+        arm_rad = self._arm_sim.getAngle()
+        arm_rps_motor = (
+            self._arm_sim.getVelocity() / (2 * math.pi)
+        ) * kHoodMotor.SIM_GEARING
+
+        self._motor.sim_state.set_rotor_velocity(arm_rps_motor)
+        self._motor.sim_state.add_rotor_position(arm_rps_motor * 0.02)
+
+        # Simulate limit switches at physical stops
+        tol = degreesToRadians(1.0)
+        self._motor.sim_state.set_forward_limit(
+            arm_rad >= degreesToRadians(kHoodMotor.MAX_ANGLE_DEG) - tol
         )
-        return np.interp(
-            distance, interpolation_distance_data, interpolation_angle_data
+        self._motor.sim_state.set_reverse_limit(
+            arm_rad <= degreesToRadians(kHoodMotor.MIN_ANGLE_DEG) + tol
         )


### PR DESCRIPTION
- Enable shot-leading in alignio.py: replace hardcoded `return 0` with dual-mode flight time estimation (physics kinematics + SHOT_TIME interpolation table), toggled via dashboard
- Add physics-based hood angle calculation using actual shooter RPM and wheel radius (fixes broken v = exit_rps * 2pi formula that gave 339 m/s)
- Add SingleJointedArmSim simulation for shooter hood with limit switches
- Add R Bumper + R Trigger combo to force physics mode (bypasses dashboard toggles for both flight time and hood angle)
- Bring SysId-measured steer/drive gains and slip current (80A) from sysid-drivetrain branch into swerve_tuner.py
- Fix TurretToPose super().__init__ passing extra shooter arg
- Fix missing super().__init__() in ShooterHood
- Add dashboard telemetry: flight time, lead offsets, velocity efficiency

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>